### PR TITLE
Add modular analysis wrapper and update pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,15 @@ results <- run_unified_pipeline(
   num_cores = 8,
   integration_method = "seurat",
   run_cluster = FALSE,        # optional
-  run_cross_iteration = TRUE  # optional
+  run_cross_iteration = TRUE, # optional
+  run_betti = FALSE           # optional
 )
 ```
 
 The wrapper runs the preprocessing and persistent homology analysis first.  If
-`run_modular_analysis()` or `run_cross_iteration()` are available they are
-invoked when the corresponding flags (`run_modular` or `run_cross_iteration`)
-are set to `TRUE`.  See the individual scripts for the detailed options of each
-step.
+`run_modular_analysis()` is available it can perform cluster comparison, Betti
+curve tests, and cross-iteration analysis based on the flags forwarded from
+`run_unified_pipeline()`.  Cross-iteration can still be executed separately when
+`run_modular = FALSE` and `run_cross_iteration = TRUE`.  See the individual
+scripts for the detailed options of each step.
 

--- a/unified_pipeline.R
+++ b/unified_pipeline.R
@@ -5,6 +5,7 @@ run_unified_pipeline <- function(metadata_path,
                                  run_cluster = FALSE,
                                  run_modular = FALSE,
                                  run_cross_iteration = FALSE,
+                                 run_betti = FALSE,
                                  ...) {
   if (!requireNamespace("readr", quietly = TRUE)) {
     stop("Package 'readr' is required")
@@ -28,9 +29,15 @@ run_unified_pipeline <- function(metadata_path,
         silent = TRUE)
   }
   if (run_modular && exists("run_modular_analysis")) {
-    try(run_modular_analysis(ph_results, results_dir = results_dir, ...), silent = TRUE)
+    try(run_modular_analysis(ph_results,
+                             results_dir = results_dir,
+                             run_cluster = run_cluster,
+                             run_betti = run_betti,
+                             run_cross_iteration = run_cross_iteration,
+                             ...),
+        silent = TRUE)
   }
-  if (run_cross_iteration && exists("run_cross_iteration")) {
+  if (run_cross_iteration && !run_modular && exists("run_cross_iteration")) {
     if (!is.null(ph_results$data_iterations)) {
       try(run_cross_iteration(ph_results$data_iterations,
                               results_folder = results_dir,
@@ -40,5 +47,4 @@ run_unified_pipeline <- function(metadata_path,
       warning("Cross iteration requested but 'data_iterations' not found in results")
     }
   }
-  ph_results
-}
+  ph_results}


### PR DESCRIPTION
## Summary
- implement `run_modular_analysis` in `PH_PostProcessing_andAnalysis.R`
- pass cluster comparison, Betti analysis, and cross-iteration flags from the unified pipeline
- update README with `run_betti` usage

## Testing
- `Rscript` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e0d83537c832385903d0464d354e1