### PR TITLE
Add unified postprocessing pipeline

### DIFF
--- a/cluster_comparison.R
+++ b/cluster_comparison.R
@@ -1,3 +1,8 @@
+#' Compare clustering results across methods.
+#'
+#' This function assumes clustering has already been performed on the
+#' provided Seurat objects.  It collects the clustering columns and
+#' produces comparative metrics and plots.
 run_cluster_comparison <- function(data_iterations, results_folder,
                                    run_comparative_metrics = TRUE,
                                    include_silhouette = FALSE,

--- a/unified_pipeline.R
+++ b/unified_pipeline.R
@@ -11,9 +11,7 @@ run_unified_pipeline <- function(metadata_path,
     stop("Package 'readr' is required")
   }
   source("PH_Calculation.R")
-  if (run_cluster) {
-    source("cluster_comparison.R")
-  }
+  source("PH_PostProcessing_andAnalysis.R")
   if (!dir.exists(results_dir)) {
     dir.create(results_dir, recursive = TRUE)
   }
@@ -22,29 +20,11 @@ run_unified_pipeline <- function(metadata_path,
                                     integration_method = integration_method,
                                     num_cores = num_cores,
                                     ...)
-  if (run_cluster && exists("run_cluster_comparison")) {
-    try(run_cluster_comparison(ph_results$data_iterations,
-                               results_folder = results_dir,
-                               ...),
+  if (run_cluster || run_modular || run_cross_iteration || run_betti) {
+    try(run_postprocessing_pipeline(ph_results,
+                                    results_dir = results_dir,
+                                    num_cores = num_cores,
+                                    ...),
         silent = TRUE)
-  }
-  if (run_modular && exists("run_modular_analysis")) {
-    try(run_modular_analysis(ph_results,
-                             results_dir = results_dir,
-                             run_cluster = run_cluster,
-                             run_betti = run_betti,
-                             run_cross_iteration = run_cross_iteration,
-                             ...),
-        silent = TRUE)
-  }
-  if (run_cross_iteration && !run_modular && exists("run_cross_iteration")) {
-    if (!is.null(ph_results$data_iterations)) {
-      try(run_cross_iteration(ph_results$data_iterations,
-                              results_folder = results_dir,
-                              ...),
-          silent = TRUE)
-    } else {
-      warning("Cross iteration requested but 'data_iterations' not found in results")
-    }
-  }
-  ph_results}
+  }  ph_results
+}


### PR DESCRIPTION
## Summary
- implement `run_postprocessing_pipeline` that computes matrices, performs clustering and runs all post‑processing steps
- update cluster comparison docs to note clustering must already exist
- update unified pipeline to call the new unified postprocessing function

## Testing
- `git commit -m "Add unified postprocessing pipeline"`

------
https://chatgpt.com/codex/tasks/task_e_686e14191fdc832389a7c47059070dc5