### PR TITLE
Remove PH retries and rename PD lists

### DIFF
--- a/R/ph_utils.R
+++ b/R/ph_utils.R
@@ -60,7 +60,7 @@ assemble_ph_results <- function(merged_unintegrated, integrated,
       assay = "RNA",
       bdm_matrix = "BDM_unintegrated_Raw.rds",
       sdm_matrix = "SDM_unintegrated_Raw.rds",
-      pd_list = "PD_list_after_retries_unintegrated_Raw.rds",
+      pd_list = "PD_list_unintegrated_Raw.rds",
       expr_list = expr_list_raw
     ),
     list(
@@ -69,7 +69,7 @@ assemble_ph_results <- function(merged_unintegrated, integrated,
       assay = "SCT_Ind",
       bdm_matrix = "BDM_unintegrated_sctInd.rds",
       sdm_matrix = "SDM_unintegrated_sctInd.rds",
-      pd_list = "PD_list_after_retries_unintegrated_sctInd.rds",
+      pd_list = "PD_list_unintegrated_sctInd.rds",
       expr_list = expr_list_sctInd
     ),
     list(
@@ -78,7 +78,7 @@ assemble_ph_results <- function(merged_unintegrated, integrated,
       assay = "SCT",
       bdm_matrix = "BDM_unintegrated_sctWhole.rds",
       sdm_matrix = "SDM_unintegrated_sctWhole.rds",
-      pd_list = "PD_list_after_retries_unintegrated_sctWhole.rds",
+      pd_list = "PD_list_unintegrated_sctWhole.rds",
       expr_list = expr_list_sctWhole
     ),
     list(
@@ -87,7 +87,7 @@ assemble_ph_results <- function(merged_unintegrated, integrated,
       assay = "integrated",
       bdm_matrix = "BDM_integrated.rds",
       sdm_matrix = "SDM_integrated.rds",
-      pd_list = "PD_list_after_retries_integrated.rds",
+      pd_list = "PD_list_integrated.rds",
       expr_list = expr_list_integrated
     )
   )


### PR DESCRIPTION
## Summary
- disable persistent homology retries by default
- update docs to describe the simplified workflow
- rename PD list files to drop `after_retries`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6884df8502f883239b8b2076945ad8e9