### PR TITLE
Improve test robustness

### DIFF
--- a/tests/testthat/test-run_unified_pipeline.R
+++ b/tests/testthat/test-run_unified_pipeline.R
@@ -26,3 +26,30 @@ test_that("run_unified_pipeline returns list structure", {
   expect_type(result, "list")
   expect_named(result, names(fake_results))
 })
+
+test_that("run_unified_pipeline creates results_dir and triggers post processing", {
+  metadata <- data.frame(`File Path` = "dummy.RData")
+  tmp <- tempfile(fileext = ".csv")
+  readr::write_csv(metadata, tmp)
+
+  results_dir <- tempfile(pattern = "results_")
+  postprocess_called <- FALSE
+  captured_results <- NULL
+
+  mock_postprocess <- function(ph_results, ...) {
+    postprocess_called <<- TRUE
+    captured_results <<- ph_results
+  }
+
+  mockr::with_mock(
+    process_datasets_PH = mock_pipeline,
+    run_postprocessing_pipeline = mock_postprocess,
+    {
+      run_unified_pipeline(tmp, results_dir = results_dir, run_cluster = TRUE)
+    }
+  )
+
+  expect_true(dir.exists(results_dir))
+  expect_true(postprocess_called)
+  expect_identical(captured_results, fake_results)
+})


### PR DESCRIPTION
## Summary
- add new test to verify results directory creation
- ensure post-processing is triggered when requested and receives expected data

No tests were run because the environment lacks the setup to execute them.

------
https://chatgpt.com/codex/tasks/task_e_6884e27f62708323a96b0f1a67a658fd