### PR TITLE
Remove unimplemented LIGER and MNN references

### DIFF
--- a/R/PH_Calculation.R
+++ b/R/PH_Calculation.R
@@ -7,8 +7,8 @@
 #' and performs statistical comparisons across different clustering methods such as UMAP 
 #' and hierarchical clustering.
 #' 
-#' It supports batch integration methods including LIGER, Seurat, and MNN (Mutual Nearest Neighbors),
-#' allowing for batch effect correction in multi-sample or multi-dataset workflows. 
+#' Batch effect correction is currently supported through Seurat integration for
+#' multi-sample or multi-dataset workflows.
 #' The final output includes persistence diagrams. Distance matrices
 #' (BDM/SDM/LDM) are produced later during post-processing along with UMAP
 #' embeddings and clustering visualizations.
@@ -25,9 +25,8 @@
 #'   
 #'   \item \strong{Persistent Homology (PH) Analysis:}
 #'     \itemize{
-#'       \item Converts `Seurat` objects into `LIGER` objects for batch correction.
 #'       \item Calculates persistence diagrams for unintegrated data using `ripserr` and `TDA` packages.
-#'       \item Integrates datasets using methods such as Seurat, LIGER, or MNN, and recalculates persistence diagrams for integrated data.
+#'       \item Integrates datasets using Seurat and recalculates persistence diagrams for integrated data.
 #'     }
 #'   
 #'   \item \strong{Distance Matrix Generation (Post-Processing):}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 ## Features
 
 * Preprocessing and integration of single-cell datasets using **Seurat**
-  (integration with LIGER and MNN is planned for a future release)
 * Calculation of persistence diagrams for each sample
 * Generation of distance matrices (Bottleneck, Spectral and Landscape) for PH objects
 * Multiple clustering approaches including standard Seurat, k-means, hierarchical PH and spectral clustering


### PR DESCRIPTION
## Summary
- update README to omit mention of LIGER/MNN integration
- update `process_datasets_PH` docs to only mention Seurat-based integration

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6884ebfb96448323806e31f0d3d5f0ad