### PR TITLE
Fix stray closing brace

### DIFF
--- a/R/PH_Functions.R
+++ b/R/PH_Functions.R
@@ -783,7 +783,6 @@ process_and_monitor <- function(expr_matrix, i, DIM, log_message, memory_thresho
       update_progress_log(log_file, i, "failed", current_threshold)
       return(list(PD = NULL, threshold = NULL))
     }
-    }
 
   }, error = function(e) {
     log_message(paste("Unexpected error in processing dataset", i, ":", e$message))


### PR DESCRIPTION
## Summary
- fix mismatched closing brace in `process_and_monitor()`

## Testing
- `python3 - <<'EOF'
import re
fname='R/PH_Functions.R'
stack=[]
with open(fname) as f:
    for lineno,line in enumerate(f,1):
        if line.strip().startswith('#'): continue
        newline=re.sub(r'".*?"','',line)
        newline=re.sub(r"'.*?'",'',newline)
        newline=newline.split('#',1)[0]
        for c in newline:
            if c=='{': stack.append(lineno)
            elif c=='}':
                if not stack:
                    print('unexpected } at line', lineno)
                else:
                    stack.pop()
if stack:
    print('unmatched { at lines', stack)
EOF

------
https://chatgpt.com/codex/tasks/task_e_6884ea259d3c83238e43d91284dc2cf8