### PR TITLE
Add toy data generation utilities

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -39,3 +39,5 @@ export(run_postprocessing_pipeline)
 export(process_datasets_PH)
 export(run_modular_analysis)
 export(run_cross_iteration)
+
+export(generate_toy_data)

--- a/R/generate_toy_data.R
+++ b/R/generate_toy_data.R
@@ -1,0 +1,16 @@
+#' Generate toy datasets
+#'
+#' This function calls the script in `inst/scripts/generate_toy_data.R`
+#' to regenerate the toy sparse expression matrices and accompanying
+#' metadata located under `inst/extdata/toy`.
+#'
+#' @return Invisibly returns TRUE on success.
+#' @export
+generate_toy_data <- function() {
+  script <- system.file("scripts", "generate_toy_data.R", package = "scPHcompare")
+  if (script == "") {
+    stop("generate_toy_data.R script not found")
+  }
+  source(script, local = FALSE)
+  invisible(TRUE)
+}

--- a/inst/extdata/toy/.gitignore
+++ b/inst/extdata/toy/.gitignore
@@ -1,0 +1,2 @@
+*.RData
+metadata.csv

--- a/inst/scripts/generate_toy_data.R
+++ b/inst/scripts/generate_toy_data.R
@@ -1,0 +1,56 @@
+#!/usr/bin/env Rscript
+
+# Script to generate toy sparse expression matrices and metadata
+# for scPHcompare package
+
+set.seed(123)
+
+suppressPackageStartupMessages({
+  library(Matrix)
+})
+
+# Determine package root based on script location
+args <- commandArgs(trailingOnly = FALSE)
+file_arg <- grep("^--file=", args)
+script_path <- if (length(file_arg)) {
+  normalizePath(sub("^--file=", "", args[file_arg]))
+} else {
+  # Fallback when running via source()
+  normalizePath(sys.frames()[[1]]$ofile)
+}
+
+pkg_root <- normalizePath(file.path(dirname(script_path), "..", ".."))
+
+out_dir <- file.path(pkg_root, "inst", "extdata", "toy")
+if (!dir.exists(out_dir)) dir.create(out_dir, recursive = TRUE, showWarnings = FALSE)
+
+samples <- data.frame(
+  sample = c("sample1", "sample2", "sample3"),
+  sra    = c("SRR000001", "SRR000002", "SRR000003"),
+  tissue = c("brain", "heart", "liver"),
+  approach = c("scRNA-seq", "scRNA-seq", "snRNA-seq"),
+  stringsAsFactors = FALSE
+)
+
+metadata <- data.frame(
+  `File Path` = character(),
+  `Sample Name` = character(),
+  SRA = character(),
+  Tissue = character(),
+  Approach = character(),
+  stringsAsFactors = FALSE
+)
+
+for (i in seq_len(nrow(samples))) {
+  m <- rsparsematrix(nrow = 100, ncol = 50, density = 0.05)
+  sample <- samples$sample[i]
+  file_rel <- file.path("inst", "extdata", "toy", paste0(sample, ".sparse.RData"))
+  file_abs <- file.path(pkg_root, file_rel)
+  save(m, file = file_abs)
+  metadata[i, ] <- list(file_rel, sample, samples$sra[i], samples$tissue[i], samples$approach[i])
+}
+
+metadata_path <- file.path(pkg_root, "inst", "extdata", "toy", "metadata.csv")
+write.csv(metadata, metadata_path, row.names = FALSE)
+
+message("Toy data and metadata generated in ", out_dir)


### PR DESCRIPTION
## Summary
- add `inst/scripts/generate_toy_data.R` to simulate toy sparse expression matrices with sample metadata
- expose `generate_toy_data()` helper to rerun the script
- remove generated toy data files and ignore future outputs

## Testing
- no tests were run


------
https://chatgpt.com/codex/tasks/task_e_689266fb91c8832383689391024b2870