### PR TITLE
feat: return toy data paths

### DIFF
--- a/R/generate_toy_data.R
+++ b/R/generate_toy_data.R
@@ -1,16 +1,27 @@
 #' Generate toy datasets
 #'
-#' This function calls the script in `inst/scripts/generate_toy_data.R`
-#' to regenerate the toy sparse expression matrices and accompanying
-#' metadata located under `inst/extdata/toy`.
+#' This function runs the helper script located at
+#' `inst/scripts/generate_toy_data.R` to recreate the toy sparse
+#' expression matrices and accompanying metadata under
+#' `inst/extdata/toy`.
 #'
-#' @return Invisibly returns TRUE on success.
+#' @return A named list with `matrices` (a character vector of paths to
+#'   the generated `.sparse.RData` files) and `metadata` (the path to the
+#'   generated `metadata.csv`).
 #' @export
 generate_toy_data <- function() {
   script <- system.file("scripts", "generate_toy_data.R", package = "scPHcompare")
   if (script == "") {
     stop("generate_toy_data.R script not found")
   }
-  source(script, local = FALSE)
-  invisible(TRUE)
+
+  env <- new.env(parent = emptyenv())
+  sys.source(script, envir = env)
+
+  files <- list(
+    matrices = file.path(env$out_dir, paste0(env$samples$sample, ".sparse.RData")),
+    metadata = env$metadata_path
+  )
+
+  files
 }


### PR DESCRIPTION
## Summary
- add `generate_toy_data()` wrapper around helper script
- return paths to generated matrices and metadata

## Testing
- `Rscript -e 'cat("R version", R.Version()$version.string, "\n")'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68926acedd88832391f8add25a0201ad