### PR TITLE
docs: mention RData input support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ library(scPHcompare)
 
 `scPHcompare` depends on several Bioconductor and CRAN packages listed in the `DESCRIPTION` file. Make sure these are available in your R environment before running the pipeline.
 
+## Input data
+
+At present `scPHcompare` mainly supports expression matrices stored in `.RData` files. Datasets in this format can be obtained from resources such as [PanglaoDB](https://panglaodb.se/) for a wide range of tissues and species. Support for other standard matrix formats is planned for a future release.
+
 ## Quick start
 
 Prepare a CSV file describing each dataset. The required columns are `File Path` and `Sample Name`. Additional metadata such as `SRA`, `Tissue` and `Approach` (scRNA‑seq or snRNA‑seq) will be preserved if provided. **At least one of `SRA`, `Tissue`, or `Approach` must be present to allow grouping and downstream analyses.** Column names can be customised when calling the pipeline. Approach labels are taken directly from the metadata and are no longer inferred automatically from expression metrics.


### PR DESCRIPTION
## Summary
- document that scPHcompare currently focuses on `.RData` input and link to PanglaoDB for datasets
- note planned support for additional standard matrix formats

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68927e9969b48323b8e4554e4b57b072