### PR TITLE
Fix syntax error in cross iteration functions

### DIFF
--- a/R/cross_iteration_functions.R
+++ b/R/cross_iteration_functions.R
@@ -1190,7 +1190,6 @@ cross_iteration_comparison_with_betti <- function(data_iterations,
         log_message(paste0("Iteration ", data_iterations[[i]]$name, " has a different number of cells; skipping renaming."))
       }
     }
-  }
   process_group <- function(group_value) {
     log_message(paste("Processing", group_by_col, ":", group_value))
     combined_pd_list <- list()


### PR DESCRIPTION
## Summary
- Remove stray closing brace so `process_group` stays within `cross_iteration_comparison_with_betti`
- Verified all R scripts parse without syntax errors

## Testing
- `R -q -e "files <- list.files('R', pattern='[.]R$', full.names=TRUE); for(f in files){cat('Checking', f, '\n'); tryCatch({parse(file=f); cat('OK\n')}, error=function(e){cat('Syntax error:', e\$message, '\n')})}"`

------
https://chatgpt.com/codex/tasks/task_e_68927ea681148323846f4d4d014645dc