### PR TITLE
Save expression lists for each PH iteration

### DIFF
--- a/R/PH_Calculation.R
+++ b/R/PH_Calculation.R
@@ -549,6 +549,7 @@ process_datasets_PH <- function(metadata,
     if (!is.null(expr_list_sctInd)) {
       log_message(paste("Successfully named expr_list_sctransformed entries by orig.ident:",
                         paste(names(expr_list_sctInd), collapse = ", ")))
+      saveRDS(expr_list_sctInd, file = paste0("expr_list_sctInd", dataset_suffix, ".Rds"))
     } else {
       log_message("expr_list_sctransformed is NULL due to an error in extraction.")
     }
@@ -584,6 +585,7 @@ process_datasets_PH <- function(metadata,
     if (!is.null(expr_list_raw)) {
       log_message(paste("Successfully named expr_list_raw entries by orig.ident:",
                         paste(names(expr_list_raw), collapse = ", ")))
+      saveRDS(expr_list_raw, file = paste0("expr_list_raw", dataset_suffix, ".Rds"))
     } else {
       log_message("expr_list_raw is NULL due to an error in extraction.")
     }
@@ -705,7 +707,7 @@ process_datasets_PH <- function(metadata,
     # Check the structure of expr_list to verify the extraction
     str(expr_list_integrated)
 
-    saveRDS(expr_list_integrated, file = "expr_list_integrated.rds")
+    saveRDS(expr_list_integrated, file = paste0("expr_list_integrated", dataset_suffix, ".Rds"))
 
     PD_result_integrated <- compute_ph_batch(
       expr_list_integrated, DIM, log_message, dataset_suffix,


### PR DESCRIPTION
## Summary
- Save SCTransform and raw expression lists after extraction to ensure availability for each iteration
- Persist integrated expression list with dataset-specific naming before PH computation

## Testing
- `Rscript -e "cat('Skipping tests as per user instructions\n')"`


------
https://chatgpt.com/codex/tasks/task_e_68929a64b2548323a0240497b0317f06