### PR TITLE
Use dataset suffix in filtered cells metadata file

### DIFF
--- a/R/PH_Calculation.R
+++ b/R/PH_Calculation.R
@@ -316,9 +316,9 @@ process_datasets_PH <- function(metadata,
       NULL
     }
   )
-  
-  
-  filtered_cells_file <- "filtered_cells.csv"
+
+
+  filtered_cells_file <- paste0("filtered_cells", dataset_suffix, ".csv")
 
   # Function to extract columns with constant values from metadata
   get_constant_metadata <- function(obj) {


### PR DESCRIPTION
## Summary
- Include `dataset_suffix` when naming filtered cells metadata files

## Testing
- `R -q -e "tryCatch({parse('R/PH_Calculation.R'); cat('Parse successful\n')}, error=function(e){cat('Parse failed: ', e$message, '\n')})"`


------
https://chatgpt.com/codex/tasks/task_e_6892a186caac832381728db3c3d95fbc