### PR TITLE
Remove datasets_to_drop argument

### DIFF
--- a/R/PH_Calculation.R
+++ b/R/PH_Calculation.R
@@ -83,7 +83,6 @@
 #' @param DIM Dimensionality for persistent homology calculation.
 #' @param THRESHOLD Threshold for persistence diagram calculation.
 #' @param dataset_tag Optional tag appended to output files.
-#' @param datasets_to_drop Integer vector of dataset indices to omit.
 #'
 #' @return A list containing processed iterations as well as the detected
 #'   column names for SRA, tissue and approach.
@@ -97,16 +96,13 @@
 
 
 
-# datasets_to_drop <- c(12,15,18) #going to come back to these in a future run
-
 process_datasets_PH <- function(metadata,
                                 integration_method = "seurat",
                                 num_cores = 16,
                                 MIN_CELLS = 250,
                                 DIM = 1,
                                 THRESHOLD = -1,
-                                dataset_tag = "dataset",
-                                datasets_to_drop = NULL) {
+                                dataset_tag = "dataset") {
   # Determine metadata column names and warn if missing
   sra_col <- intersect(c("SRA", "SRA_Number", "SRA Number"), colnames(metadata))[1]
   tissue_col <- intersect(c("Tissue", "tissue"), colnames(metadata))[1]

--- a/man/process_datasets_PH.Rd
+++ b/man/process_datasets_PH.Rd
@@ -11,8 +11,7 @@ process_datasets_PH(
   MIN_CELLS = 250,
   DIM = 1,
   THRESHOLD = -1,
-  dataset_tag = "dataset",
-  datasets_to_drop = NULL
+  dataset_tag = "dataset"
 )
 }
 \arguments{
@@ -30,8 +29,6 @@ process_datasets_PH(
 \item{THRESHOLD}{Threshold for persistence diagram calculation.}
 
 \item{dataset_tag}{Optional tag appended to output files.}
-
-\item{datasets_to_drop}{Integer vector of dataset indices to omit.}
 }
 \value{
 A list containing processed iterations as well as the detected


### PR DESCRIPTION
## Summary
- drop unused `datasets_to_drop` parameter from `process_datasets_PH`
- update documentation to reflect removed argument

## Testing
- `R -q -e "source('R/PH_Calculation.R')"`


------
https://chatgpt.com/codex/tasks/task_e_6892a1db59908323b2a668341f469d72