### PR TITLE
Refine hemoglobin gene filtering

### DIFF
--- a/R/PH_Calculation.R
+++ b/R/PH_Calculation.R
@@ -176,7 +176,11 @@ process_datasets_PH <- function(metadata,
       mclapply(my_seurat_list, function(obj) {
         obj <- PercentageFeatureSet(obj, pattern = "^MT-", col.name = "percent_mito")
         obj <- PercentageFeatureSet(obj, pattern = "^RP[SL]", col.name = "percent_ribo")
-        obj <- PercentageFeatureSet(obj, pattern = "^HB[^(P)]", col.name = "percent_hb")
+        # Hemoglobin genes are typically annotated as 'HB' followed by a subunit
+        # letter (e.g., HBA1, HBB). Exclude non-hemoglobin genes such as 'HBP'
+        # by using a negative lookahead.
+        obj <- PercentageFeatureSet(obj, pattern = "^HB(?!P)", perl = TRUE,
+                                    col.name = "percent_hb")
         return(obj)
       }, mc.cores = num_cores)
     },


### PR DESCRIPTION
## Summary
- Use clearer regex to compute hemoglobin gene percentage, excluding HBP genes
- Document expected gene naming convention for hemoglobin genes

## Testing
- `R -q -e 'genes <- c("HBA1","HBB","HBP1","HBZ","HBD","HBG1","HBAP1"); matches <- genes[grepl("^HB(?!P)", genes, perl=TRUE)]; print(matches)'`
- `R -q -e 'parse("R/PH_Calculation.R")'`


------
https://chatgpt.com/codex/tasks/task_e_6892a21861d88323b453d258823fe04c