### PR TITLE
Clarify MIT license in PH calculation script

### DIFF
--- a/R/PH_Calculation.R
+++ b/R/PH_Calculation.R
@@ -73,7 +73,7 @@
 #' Jonah Daneshmand
 #'
 #' @section License:
-#' [Specify the license under which the script is distributed, e.g., GPL-3]
+#' MIT License
 
 #' @param metadata Data frame with file paths and associated metadata.
 #' @param integration_method Integration method to use ("seurat",

--- a/man/process_datasets_PH.Rd
+++ b/man/process_datasets_PH.Rd
@@ -120,8 +120,7 @@ Jonah Daneshmand
 }
 
 \section{License}{
-
-[Specify the license under which the script is distributed, e.g., GPL-3]
+MIT License
 }
 
 \examples{


### PR DESCRIPTION
## Summary
- replace placeholder license in `process_datasets_PH` roxygen header with MIT License
- update documentation to show MIT License

## Testing
- `R -q -e 'roxygen2::roxygenise()'` *(fails: there is no package called 'roxygen2')*

------
https://chatgpt.com/codex/tasks/task_e_6892a21d81d88323a81bfc993554c284