### PR TITLE
Expand toy dataset generation

### DIFF
--- a/R/generate_toy_data.R
+++ b/R/generate_toy_data.R
@@ -1,9 +1,10 @@
 #' Generate toy datasets
 #'
 #' This function runs the helper script located at
-#' `inst/scripts/generate_toy_data.R` to recreate the toy sparse
+#' `inst/scripts/generate_toy_data.R` to recreate 20 toy sparse
 #' expression matrices and accompanying metadata under
-#' `inst/extdata/toy`.
+#' `inst/extdata/toy`. The datasets span five tissues, two sequencing
+#' approaches, and two SRA identifiers.
 #'
 #' @return A named list with `matrices` (a character vector of paths to
 #'   the generated `.sparse.RData` files) and `metadata` (the path to the

--- a/inst/scripts/generate_toy_data.R
+++ b/inst/scripts/generate_toy_data.R
@@ -1,7 +1,8 @@
 #!/usr/bin/env Rscript
 
 # Script to generate toy sparse expression matrices and metadata
-# for scPHcompare package
+# for scPHcompare package. Creates 20 datasets spanning 5 tissues,
+# 2 sequencing approaches and 2 SRA identifiers.
 
 set.seed(123)
 
@@ -24,13 +25,19 @@ pkg_root <- normalizePath(file.path(dirname(script_path), "..", ".."))
 out_dir <- file.path(pkg_root, "inst", "extdata", "toy")
 if (!dir.exists(out_dir)) dir.create(out_dir, recursive = TRUE, showWarnings = FALSE)
 
-samples <- data.frame(
-  sample = c("sample1", "sample2", "sample3"),
-  sra    = c("SRR000001", "SRR000002", "SRR000003"),
-  tissue = c("brain", "heart", "liver"),
-  approach = c("scRNA-seq", "scRNA-seq", "snRNA-seq"),
+tissues <- c("brain", "heart", "liver", "kidney", "lung")
+sras <- c("SRR000001", "SRR000002")
+approaches <- c("scRNA-seq", "snRNA-seq")
+
+samples <- expand.grid(
+  sra = sras,
+  tissue = tissues,
+  approach = approaches,
+  KEEP.OUT.ATTRS = FALSE,
   stringsAsFactors = FALSE
 )
+samples$sample <- sprintf("sample%02d", seq_len(nrow(samples)))
+samples <- samples[c("sample", "sra", "tissue", "approach")]
 
 metadata <- data.frame(
   `File Path` = character(),

--- a/man/generate_toy_data.Rd
+++ b/man/generate_toy_data.Rd
@@ -13,7 +13,8 @@ A named list with `matrices` (a character vector of paths to
 }
 \description{
 This function runs the helper script located at
-`inst/scripts/generate_toy_data.R` to recreate the toy sparse
+`inst/scripts/generate_toy_data.R` to recreate 20 toy sparse
 expression matrices and accompanying metadata under
-`inst/extdata/toy`.
+`inst/extdata/toy`. The datasets span five tissues, two sequencing
+approaches, and two SRA identifiers.
 }


### PR DESCRIPTION
## Summary
- generate 20 toy datasets across 5 tissues, 2 approaches, and 2 SRA IDs
- document new toy dataset composition

## Testing
- `Rscript -e "roxygen2::roxygenize()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892ab8c86cc8323819ff8f38733d7b2