### PR TITLE
Ensure PH pipeline logs messages

### DIFF
--- a/R/PH_Calculation.R
+++ b/R/PH_Calculation.R
@@ -133,9 +133,15 @@ process_datasets_PH <- function(metadata,
   dataset_suffix <- if (nzchar(dataset_tag)) paste0("_", dataset_tag) else ""
   
   # Start logging
-  log_file <- paste0("PH_Pipeline_Log_", Sys.Date(), dataset_suffix, ".txt")
+  log_file_path <- paste0("PH_Pipeline_Log_", Sys.Date(), dataset_suffix, ".txt")
+  log_file <- file(log_file_path, open = "a")
   sink(log_file, append = TRUE)
-  on.exit(sink(), add = TRUE)
+  sink(log_file, append = TRUE, type = "message")
+  on.exit({
+    sink(NULL)
+    sink(NULL, type = "message")
+    close(log_file)
+  }, add = TRUE)
   
   # Helper functions are available once the package is loaded
   


### PR DESCRIPTION
## Summary
- Capture both output and message streams in the PH pipeline log file.
- Guarantee log sinks are restored and file handle closed on exit.

## Testing
- `R -q -e 'log_file_path<-"temp_log.txt";log_file<-file(log_file_path,open="a");sink(log_file,append=TRUE);sink(log_file,append=TRUE,type="message");message("message output");cat("cat output\n");sink(NULL,type="message");sink(NULL);close(log_file);cat(readLines(log_file_path),sep="\n")'`

------
https://chatgpt.com/codex/tasks/task_e_6892b425deb8832397219c5067cdb1c3