### PR TITLE
Add existence check to load_sparse_matrices and unit tests

### DIFF
--- a/R/ph_utils.R
+++ b/R/ph_utils.R
@@ -5,6 +5,16 @@ load_sparse_matrices <- function(file_paths) {
   if (length(file_paths) == 0) {
     return(list(matrices = list(), sample_names = character(0)))
   }
+  missing <- file_paths[!file.exists(file_paths)]
+  if (length(missing) > 0) {
+    stop(
+      sprintf(
+        "The following files do not exist: %s",
+        paste(missing, collapse = ", ")
+      ),
+      call. = FALSE
+    )
+  }
   sparse_matrices <- lapply(file_paths, loadRData)
   sample_names <- gsub(".*/|\\.sparse.RData$", "", file_paths)
   names(sparse_matrices) <- sample_names

--- a/tests/testthat/test-load_sparse_matrices.R
+++ b/tests/testthat/test-load_sparse_matrices.R
@@ -1,0 +1,17 @@
+library(testthat)
+library(scPHcompare)
+
+test_that("load_sparse_matrices loads existing files", {
+  tmp <- tempfile(fileext = ".sparse.RData")
+  mat <- matrix(1:4, nrow = 2)
+  save(mat, file = tmp)
+  res <- load_sparse_matrices(tmp)
+  expected_name <- gsub(".*/|\\.sparse.RData$", "", tmp)
+  expect_equal(res$sample_names, expected_name)
+  expect_equal(res$matrices[[1]], mat)
+})
+
+test_that("load_sparse_matrices errors for missing files", {
+  missing <- tempfile(fileext = ".sparse.RData")
+  expect_error(load_sparse_matrices(missing), "do not exist")
+})


### PR DESCRIPTION
## Summary
- validate file paths before loading sparse matrices and error with descriptive message when missing
- add unit tests covering successful loads and missing-file errors

## Testing
- `R CMD build .` *(fails: command not found: R)*

------
https://chatgpt.com/codex/tasks/task_e_6892b43ea378832397f46c1e67cbfc1b