### PR TITLE
Document helper utilities with roxygen comments

### DIFF
--- a/R/logging_utils.R
+++ b/R/logging_utils.R
@@ -1,7 +1,13 @@
 #' Logging utilities
 #'
 #' Provides a simple logging helper that prepends timestamps to messages.
+#'
+#' @param msg Character string to log.
+#' @return Invisibly returns `NULL` after printing the message.
+#' @examples
+#' log_message("processing")
 log_message <- function(msg) {
   message(sprintf("[%s] %s", Sys.time(), msg))
+  invisible(NULL)
 }
 


### PR DESCRIPTION
## Summary
- add roxygen documentation for helper functions like `normalize_curve`, `compute_betti_curve`, and caching utilities
- document logging helper `log_message`

## Testing
- `R -q -e "invisible(parse('R/cross_iteration_functions.R')); invisible(parse('R/logging_utils.R')); cat('parsed\\n')"`


------
https://chatgpt.com/codex/tasks/task_e_6892bbd56ac48323b76cfb644d089c57