### PR TITLE
docs: document renv usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ library(scPHcompare)
 
 `scPHcompare` depends on several Bioconductor and CRAN packages listed in the `DESCRIPTION` file. Make sure these are available in your R environment before running the pipeline.
 
+## Dependency management with renv
+
+This repository tracks its R package dependencies with [renv](https://rstudio.github.io/renv/). After cloning the repository, install `renv` if necessary and restore the lockfile to create a project-local library:
+
+```r
+# install.packages("renv")  # run once per machine
+renv::restore()
+```
+
+`renv::restore()` installs the specific package versions recorded in `renv.lock`. R sessions started from the project root automatically use this library; alternatively call `renv::activate()` manually. If you add or upgrade packages, run `renv::snapshot()` to update the lockfile before committing.
+
 ## Input data
 
 At present `scPHcompare` mainly supports expression matrices stored in `.RData` files. Datasets in this format can be obtained from resources such as [PanglaoDB](https://panglaodb.se/) for a wide range of tissues and species. Support for other standard matrix formats is planned for a future release.


### PR DESCRIPTION
## Summary
- add README instructions for restoring and managing the renv project library

## Testing
- `python - <<'PY'
print('No tests run per user instruction')
PY`


------
https://chatgpt.com/codex/tasks/task_e_6892c32d8a7c83238fd1149d1d322cc6