### PR TITLE
Refactor modular pipeline flags

### DIFF
--- a/R/PH_PostProcessing_andAnalysis.R
+++ b/R/PH_PostProcessing_andAnalysis.R
@@ -486,6 +486,9 @@ run_modular_analysis <- function(ph_results,
 #' @param run_spectral_clustering Logical, run spectral clustering.
 #' @param run_visualizations Logical, generate plots for each iteration.
 #' @param run_sample_level_heatmap Logical, create sample-level heatmaps.
+#' @param run_cluster Logical, run clustering comparisons if `TRUE`.
+#' @param run_betti Logical, compute Betti curves if `TRUE`.
+#' @param run_cross_iteration Logical, run cross-iteration analysis.
 #' @param metadata_path Optional path to metadata CSV for plotting.
 #' @param SRA_col Metadata column with sample identifiers.
 #' @param Tissue_col Metadata column containing tissue labels.
@@ -509,6 +512,9 @@ run_postprocessing_pipeline <- function(ph_results,
                                         run_spectral_clustering = TRUE,
                                         run_visualizations = TRUE,
                                         run_sample_level_heatmap = TRUE,
+                                        run_cluster = TRUE,
+                                        run_betti = TRUE,
+                                        run_cross_iteration = TRUE,
                                         metadata_path = "./data/VastlyDifferentTissues/metadata.csv",
                                         SRA_col = "orig.ident",
                                         Tissue_col = "Tissue",
@@ -595,15 +601,17 @@ run_postprocessing_pipeline <- function(ph_results,
 
   ph_results$data_iterations <- data_iterations
 
-  run_modular_analysis(ph_results,
-                       results_dir = results_dir,
-                       run_cluster = TRUE,
-                       run_betti = TRUE,
-                       run_cross_iteration = TRUE,
-                       SRA_col = SRA_col,
-                       Tissue_col = Tissue_col,
-                       Approach_col = Approach_col,
-                       ...)
+  if (run_cluster || run_betti || run_cross_iteration) {
+    run_modular_analysis(ph_results,
+                         results_dir = results_dir,
+                         run_cluster = run_cluster,
+                         run_betti = run_betti,
+                         run_cross_iteration = run_cross_iteration,
+                         SRA_col = SRA_col,
+                         Tissue_col = Tissue_col,
+                         Approach_col = Approach_col,
+                         ...)
+  }
 
   invisible(ph_results)
 }

--- a/R/unified_pipeline.R
+++ b/R/unified_pipeline.R
@@ -11,7 +11,7 @@
 #'   datasets. Options include "seurat", "liger" or "mnn".
 #' @param run_cluster If `TRUE`, run clustering comparisons during
 #'   post-processing.
-#' @param run_modular If `TRUE`, perform modular analyses.
+#' @param run_cross_iteration If `TRUE`, perform cross-iteration analyses.
 #' @param run_betti If `TRUE`, compute and compare Betti curves.
 #' @param ... Additional arguments passed to the underlying processing
 #'   functions.
@@ -30,8 +30,8 @@ run_unified_pipeline <- function(metadata_path,
                                  num_cores = 8,
                                  integration_method = "seurat",
                                  run_cluster = FALSE,
-                                 run_modular = FALSE,
                                  run_betti = FALSE,
+                                 run_cross_iteration = FALSE,
                                  ...) {
   if (!requireNamespace("readr", quietly = TRUE)) {
     stop("Package 'readr' is required")
@@ -45,11 +45,14 @@ run_unified_pipeline <- function(metadata_path,
                                     integration_method = integration_method,
                                     num_cores = num_cores,
                                     ...)
-  if (run_cluster || run_modular || run_betti) {
+  if (run_cluster || run_betti || run_cross_iteration) {
     tryCatch(
       run_postprocessing_pipeline(ph_results,
                                   results_dir = results_dir,
                                   num_cores = num_cores,
+                                  run_cluster = run_cluster,
+                                  run_betti = run_betti,
+                                  run_cross_iteration = run_cross_iteration,
                                   metadata_path = metadata_path,
                                   SRA_col = ph_results$SRA_col,
                                   Tissue_col = ph_results$Tissue_col,

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ results <- run_unified_pipeline(
   results_dir = "results",
   num_cores = 8,
   integration_method = "seurat",
-  run_modular = TRUE,   # modular step incl. cross‑iteration comparisons
-  run_cluster = TRUE,   # optional cluster metrics output
-  run_betti = TRUE      # optional Betti curve comparison
+  run_cluster = TRUE,        # optional cluster metrics output
+  run_betti = TRUE,          # optional Betti curve comparison
+  run_cross_iteration = TRUE # cross-iteration comparisons
 )
 ```
 

--- a/man/run_postprocessing_pipeline.Rd
+++ b/man/run_postprocessing_pipeline.Rd
@@ -14,6 +14,9 @@ run_postprocessing_pipeline(
   run_spectral_clustering = TRUE,
   run_visualizations = TRUE,
   run_sample_level_heatmap = TRUE,
+  run_cluster = TRUE,
+  run_betti = TRUE,
+  run_cross_iteration = TRUE,
   metadata_path = "./data/VastlyDifferentTissues/metadata.csv",
   SRA_col = "orig.ident",
   Tissue_col = "Tissue",
@@ -40,6 +43,12 @@ clustering on PH distances.}
 \item{run_visualizations}{Logical, generate plots for each iteration.}
 
 \item{run_sample_level_heatmap}{Logical, create sample-level heatmaps.}
+
+\item{run_cluster}{Logical, run clustering comparisons if `TRUE`.}
+
+\item{run_betti}{Logical, compute Betti curves if `TRUE`.}
+
+\item{run_cross_iteration}{Logical, run cross-iteration analysis.}
 
 \item{metadata_path}{Optional path to metadata CSV for plotting.}
 

--- a/man/run_unified_pipeline.Rd
+++ b/man/run_unified_pipeline.Rd
@@ -10,8 +10,8 @@ run_unified_pipeline(
   num_cores = 8,
   integration_method = "seurat",
   run_cluster = FALSE,
-  run_modular = FALSE,
   run_betti = FALSE,
+  run_cross_iteration = FALSE,
   ...
 )
 }
@@ -28,9 +28,9 @@ datasets. Options include "seurat", "liger" or "mnn".}
 \item{run_cluster}{If `TRUE`, run clustering comparisons during
 post-processing.}
 
-\item{run_modular}{If `TRUE`, perform modular analyses.}
-
 \item{run_betti}{If `TRUE`, compute and compare Betti curves.}
+
+\item{run_cross_iteration}{If `TRUE`, perform cross-iteration analyses.}
 
 \item{...}{Additional arguments passed to the underlying processing
 functions.}

--- a/tests/testthat/test-postprocessing_modules.R
+++ b/tests/testthat/test-postprocessing_modules.R
@@ -50,6 +50,9 @@ test_that("run_postprocessing_pipeline calls run_modular_analysis", {
         run_spectral_clustering = FALSE,
         run_visualizations = FALSE,
         run_sample_level_heatmap = FALSE,
+        run_cluster = TRUE,
+        run_betti = FALSE,
+        run_cross_iteration = FALSE,
         metadata_path = NULL
       )
     }


### PR DESCRIPTION
## Summary
- expose `run_cross_iteration` flag in `run_unified_pipeline` and drop `run_modular`
- allow `run_postprocessing_pipeline` to selectively run cluster, Betti, and cross-iteration modules
- document new behavior and update tests

## Testing
- `R --vanilla -q -e 'source("R/unified_pipeline.R"); source("R/PH_PostProcessing_andAnalysis.R"); cat("loaded\\n")'`


------
https://chatgpt.com/codex/tasks/task_e_6892d64f9cac8323b93c808e4a1bafc7