### PR TITLE
Increase toy dataset cell count to 300

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ library(scPHcompare)
 toy_files <- generate_toy_data()
 ```
 
-`generate_toy_data()` recreates 20 sparse 100×50 matrices spanning five tissues, two sequencing approaches (`scRNA-seq` and `snRNA-seq`), and two SRA identifiers. The matrices and a corresponding `metadata.csv` file are written to `inst/extdata/toy/` and their paths are returned. The metadata can then be used to run the pipeline:
+`generate_toy_data()` recreates 20 sparse 100×300 matrices spanning five tissues, two sequencing approaches (`scRNA-seq` and `snRNA-seq`), and two SRA identifiers. The matrices and a corresponding `metadata.csv` file are written to `inst/extdata/toy/` and their paths are returned. The metadata can then be used to run the pipeline:
 
 ```r
 results <- run_unified_pipeline(

--- a/inst/scripts/generate_toy_data.R
+++ b/inst/scripts/generate_toy_data.R
@@ -49,7 +49,7 @@ metadata <- data.frame(
 )
 
 for (i in seq_len(nrow(samples))) {
-  m <- rsparsematrix(nrow = 100, ncol = 50, density = 0.05)
+  m <- rsparsematrix(nrow = 100, ncol = 300, density = 0.05)
   sample <- samples$sample[i]
   file_rel <- file.path("inst", "extdata", "toy", paste0(sample, ".sparse.RData"))
   file_abs <- file.path(pkg_root, file_rel)


### PR DESCRIPTION
## Summary
- Ensure generated toy datasets include 300 cells per sample.
- Update README to reflect the new 100×300 matrix size.

## Testing
- `Rscript -e 'library(Matrix); m <- rsparsematrix(nrow = 100, ncol = 300, density = 0.05); print(dim(m))'`


------
https://chatgpt.com/codex/tasks/task_e_6892de557aec8323862a4e4b7c2c5eb3