### PR TITLE
Ensure threshold extraction uses provided logger

### DIFF
--- a/R/PH_Functions.R
+++ b/R/PH_Functions.R
@@ -528,14 +528,18 @@ process_expression_list_with_monitoring <- function(expr_list, DIM, log_message,
 
   # Extract final thresholds from the progress log file
   log_message("Extracting thresholds from the progress log file.")
-  threshold_tracker <- extract_thresholds_from_log(log_file)
+  threshold_tracker <- extract_thresholds_from_log(log_file, log_message)
 
   return(list(PD_list = PD_list, thresholds = threshold_tracker))
 }
 
 
 # Function to extract thresholds from the progress log
-extract_thresholds_from_log <- function(log_file) {
+extract_thresholds_from_log <- function(log_file, log_message = message) {
+  if (is.null(log_message)) {
+    log_message <- message
+  }
+
   # Check if the log file exists
   if (!file.exists(log_file)) {
     log_message(paste("Log file", log_file, "does not exist. Returning an empty threshold tracker."))


### PR DESCRIPTION
## Summary
- pass the active logging function into threshold extraction to keep logs consistent
- default threshold extraction logging to base `message()` when no logger is provided

## Testing
- not run (per instructions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c1e31ea7c8323817d0960bff3c39a)